### PR TITLE
Dockerfile – upgrade pip without using curl

### DIFF
--- a/dockerfiles/dev.Dockerfile
+++ b/dockerfiles/dev.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-ENV APP_HOME /srv/www/django/microweb/
+ENV APP_HOME=/srv/www/django/microweb/
 
 
 WORKDIR ${APP_HOME}
@@ -18,11 +18,9 @@ RUN apt-get -qq update && \
 
 COPY requirements.txt /${APP_HOME}
 
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
-    && python get-pip.py \
-    && rm get-pip.py \
-    && pip install virtualenv \
-    && pip install -r requirements.txt
+RUN python -m pip install --upgrade pip \
+	&& pip install virtualenv \
+	&& pip install -r requirements.txt
 
 COPY . /${APP_HOME}
 # RUN ./dependencies.sh
@@ -34,6 +32,6 @@ ADD https://www.lfgss.com/static/themes/1/css/bootstrap.min.css ${APP_HOME}core/
 
 RUN [ ! -f microweb/local_settings.py ] && echo "Missing config. Using default. Should be fine." && cp microweb/local_settings.py.sample microweb/local_settings.py
 
-ENV PORT 80
+ENV PORT=80
 EXPOSE ${PORT}
 CMD python ./ENV/bin/gunicorn_django -b 0.0.0.0:${PORT}


### PR DESCRIPTION
Every build was getting a segfault at the curl request for me, so I've switched it to just use `python -m pip install --upgrade pip`