### PR TITLE
Remove fabric from dev.Dockerfile

### DIFF
--- a/dockerfiles/dev.Dockerfile
+++ b/dockerfiles/dev.Dockerfile
@@ -8,7 +8,6 @@ WORKDIR ${APP_HOME}
 RUN apt-get -qq update && \
     apt-get -yq install --no-install-recommends \
         build-essential \
-        fabric \
         libevent-dev \
         libmemcached-dev \
         zlib1g-dev && \


### PR DESCRIPTION
In my case, the install of fabric via apt was leading to the "Setting up python-enum34" hanging indefinitely, similarly to this StackOverflow question: https://stackoverflow.com/questions/76042150/python-install-in-ubuntu-docker-image-hangs-at-python-pkg-resources

It is not used anyway to run the development environment so we can simply remove it.