### PR TITLE
Dockerfile: use gunicorn installed by pip

### DIFF
--- a/dockerfiles/dev.Dockerfile
+++ b/dockerfiles/dev.Dockerfile
@@ -35,4 +35,4 @@ RUN [ ! -f microweb/local_settings.py ] && echo "Missing config. Using default. 
 
 ENV PORT 80
 EXPOSE ${PORT}
-CMD python ./ENV/bin/gunicorn_django -b 0.0.0.0:${PORT}
+CMD python /usr/local/bin/gunicorn_django -b 0.0.0.0:${PORT}


### PR DESCRIPTION
* this is the copy of gunicorn freshly installed by pip earlier in the dockerfile
* *don't* use the hardcoded version of gunicorn from the old ENV directory
* so that we can update gunicorn in future!
* nb. if we start using a virtualenv in dockerfiles, this should point to that env