### PR TITLE
Use whitenoise for static assets when debug is false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN cp microweb/local_settings.py.production microweb/local_settings.py
 
 # add dummy user
 RUN useradd -Ms /bin/bash -u1100 microweb
+
+RUN mkdir -p /srv/www/django/static/
+RUN python manage.py collectstatic
+RUN chown -R microweb:microweb /srv/www/django/static/
+
+# switch to the unprivileged user to run gunicorn
 USER microweb
 
 ENV PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,14 @@ RUN cp microweb/local_settings.py.production microweb/local_settings.py
 RUN useradd -Ms /bin/bash -u1100 microweb
 
 RUN mkdir -p /srv/www/django/static/
-RUN python manage.py collectstatic
+# The correct thing to do is run collectstatic like this:
+# RUN python manage.py collectstatic --pythonpath=. --settings=microweb.settings
+# However for some reason the staticfiles module is not loading at this point
+# (You can see this by running `python manage.py help` here & inspecting the list).
+# Connecting to the container later collectstatic runs fine, however if the files
+# aren't in place before gunicorn starts, it won't recognise them & you'll get 404s!
+# So let's do our own hacky collectstatic like so:
+COPY ./core/static/ /srv/www/django/static/
 RUN chown -R microweb:microweb /srv/www/django/static/
 
 # switch to the unprivileged user to run gunicorn

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load staticfiles %}
 <!DOCTYPE html>
 <html lang="en">
 	<head>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,3 +1,4 @@
+{% load static from staticfiles %}
 <!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -293,7 +294,7 @@
 
 		<script src="{{ STATIC_URL }}3rd/jquery/1.10.2/jquery.min.js"></script>
 		<script src="{{ STATIC_URL }}3rd/moment.js/2.10.6/moment.min.js"></script>
-		<script src="{{ STATIC_URL }}3rd/prettify/r298/prettify.js"></script>
+		<script src="{% static "3rd/prettify/r298/prettify.js" %}"></script>
 		<script src="{{ STATIC_URL }}js/bootstrap.min.js"></script>
 		<script src="{{ STATIC_URL }}js/base.js"></script>
 		<script src="{{ STATIC_URL }}js/metabar.js?v=20160619"></script>

--- a/microweb/local_settings.py.production
+++ b/microweb/local_settings.py.production
@@ -15,6 +15,10 @@ SECRET_KEY = os.getenv('SECRET_KEY', '')
 DEBUG = False
 TEMPLATE_DEBUG = False
 
+# Absolute path to the directory static files should be collected to.
+# In production with Docker these are served by whitenoise.
+STATIC_ROOT = '/srv/www/django/static/'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/microweb/settings.py
+++ b/microweb/settings.py
@@ -46,7 +46,7 @@ MEDIA_ROOT = ''
 MEDIA_URL = ''
 
 # Absolute path to the directory static files should be collected to.
-# In production these are served by nginx.
+# In production these are served by ~~nginx~~ or maybe whitenoise.
 STATIC_ROOT = '/srv/www/django/microweb/static/'
 
 # URL prefix for static files.
@@ -169,3 +169,6 @@ from microweb.local_settings import SECRET_KEY
 # Allows shadowing of DEBUG for development.
 from microweb.local_settings import DEBUG
 from microweb.local_settings import TEMPLATE_DEBUG
+
+# Allow override of STATIC_ROOT for production
+from microweb.local_settings import STATIC_ROOT

--- a/microweb/wsgi.py
+++ b/microweb/wsgi.py
@@ -21,7 +21,9 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "microweb.settings")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
 application = get_wsgi_application()
+application = DjangoWhiteNoise(application)
 
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ pylibmc==1.2.3
 grequests==0.2.0
 
 newrelic==2.16.0.12
+
+whitenoise==2.0.6


### PR DESCRIPTION
CloudFlare serve most of our assets from their cache, so we don't need high performance, so we don't need to figure out how to ship the assets out of the Docker container & serve them with nginx. Instead, we just add this nifty thing - [whitenoise](https://github.com/evansd/whitenoise/blob/v2.0.6/docs/index.rst) in a vintage version.

fixes #32 