### PR TITLE
Allow upstream to set proto https

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -152,6 +152,8 @@ dokku nginx:set microweb proxy-send-timeout 90s
 dokku nginx:set microweb proxy-read-timeout 90s
 dokku nginx:set microweb proxy-buffers "32 4k"
 dokku nginx:set microweb client-max-body-size 30m
+# nb. if forwarded-proto is set to $scheme, gunicorn sees http
+dokku nginx:set microweb x-forwarded-proto-value https
 # need to run a rebuild for this config to take effect
 dokku ps:rebuild microweb
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ USER microweb
 
 ENV PORT=80
 EXPOSE ${PORT}
-CMD python /usr/local/bin/gunicorn microweb.wsgi -b 0.0.0.0:${PORT}
+CMD python /usr/local/bin/gunicorn microweb.wsgi -b 0.0.0.0:${PORT} --forwarded-allow-ips '*'


### PR DESCRIPTION
* this isn't ideal, but we do have a firewall so only the api & lb servers can connect
* attempting to fix the problem that django is redirecting requests to http
* fixes #35 
* https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips
