### PR TITLE
Better host handling

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -142,6 +142,9 @@ dokku config:set --no-restart microweb MEMCACHE_HOST=dokku-memcached-microweb-me
 dokku config:set --no-restart microweb CLIENT_SECRET=123456
 # use single quotes if you have special chars!
 dokku config:set --no-restart microweb SECRET_KEY='!aoeui12345'
+# Python library `requests` ships its own CA bundle which is outdated and fails to verify
+# modern certificates (in Python 2.7). Override it to use the system CA bundle instead.
+dokku config:set --no-restart microweb REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 ```
 
 Add some nginx config:

--- a/core/middleware/context.py
+++ b/core/middleware/context.py
@@ -4,8 +4,10 @@ import pylibmc as memcache
 
 from django.conf import settings
 
+from django.http import HttpResponseNotFound
 from django.http import HttpResponseRedirect
 
+from core.api.exceptions import APIException
 from core.api.resources import Site
 from core.api.resources import WhoAmI
 
@@ -31,15 +33,21 @@ class ContextMiddleware():
         request.whoami_url = ''
         request.view_requests = []
 
-        if request.COOKIES.has_key('access_token'):
-            # Clean up empty access token.
-            if request.COOKIES['access_token'] == '':
-                response = HttpResponseRedirect('/')
-                response.set_cookie('access_token', '', expires="Thu, 01 Jan 1970 00:00:00 GMT")
-                return response
-            request.access_token = request.COOKIES['access_token']
-            request.whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
-            request.view_requests.append(grequests.get(request.whoami_url, params=params, headers=headers))
+        try:
+            if request.COOKIES.has_key('access_token'):
+                # Clean up empty access token.
+                if request.COOKIES['access_token'] == '':
+                    response = HttpResponseRedirect('/')
+                    response.set_cookie('access_token', '', expires="Thu, 01 Jan 1970 00:00:00 GMT")
+                    return response
+                request.access_token = request.COOKIES['access_token']
+                request.whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
+                request.view_requests.append(grequests.get(request.whoami_url, params=params, headers=headers))
 
-        request.site_url, params, headers = Site.build_request(request.get_host())
-        request.view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
+            request.site_url, params, headers = Site.build_request(request.get_host())
+            request.view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
+        except APIException as e:
+            if e.status_code in [400, 404]:
+                logger.warning('Rejecting unresolved host %s: %s' % (request.get_host(), str(e)))
+                return HttpResponseNotFound()
+            raise

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -19,6 +19,8 @@ from core.api.resources import Site
 from core.api.resources import Event
 from core.api.resources import build_url
 from core.api.exceptions import APIException
+from core.middleware.context import ContextMiddleware
+from core.views import ErrorView
 
 TEST_ROOT = os.path.dirname(os.path.abspath(__file__))
 
@@ -203,3 +205,35 @@ class ResourceTests(unittest.TestCase):
     def testSiteInit(self):
         data = json.loads(open(os.path.join(TEST_ROOT, 'data', 'site.json')).read())['data']
         Site(data)
+
+
+class ErrorHandlingTests(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @patch('core.middleware.context.Site.build_request')
+    def testContextMiddlewareReturns404ForUnknownHost(self, mock_build_request):
+        request = self.factory.get('/', HTTP_HOST='139.162.251.45')
+        mock_build_request.side_effect = APIException('Error resolving CNAME 139.162.251.45', 404)
+
+        middleware = ContextMiddleware()
+        response = middleware.process_request(request)
+
+        assert response.status_code == 404
+
+    @patch('core.views.loader.get_template')
+    @patch('core.views.Site.build_request')
+    def testServerErrorDoesNotRecurseOnUnknownHost(self, mock_build_request, mock_get_template):
+        request = self.factory.get('/', HTTP_HOST='139.162.251.45')
+        mock_build_request.side_effect = APIException('Error resolving CNAME 139.162.251.45', 404)
+
+        class DummyTemplate(object):
+            def render(self, context):
+                return 'server error'
+
+        mock_get_template.return_value = DummyTemplate()
+        response = ErrorView.server_error(request)
+
+        assert response.status_code == 500
+        assert response.content == 'server error'

--- a/core/views.py
+++ b/core/views.py
@@ -51,6 +51,39 @@ from core.api.resources import build_url
 
 logger = logging.getLogger('core.views')
 
+
+def build_error_view_data(request, include_user=False):
+    """
+    Best-effort context for error pages. Unknown hosts should not trigger a second failure.
+    """
+
+    view_data = {}
+    view_requests = []
+    whoami_url = None
+    site_url = None
+
+    try:
+        if include_user and request.COOKIES.has_key('access_token'):
+            request.access_token = request.COOKIES['access_token']
+            whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
+            view_requests.append(grequests.get(whoami_url, params=params, headers=headers))
+
+        site_url, params, headers = Site.build_request(request.get_host())
+        view_requests.append(grequests.get(site_url, params=params, headers=headers))
+    except APIException as exc:
+        logger.warning('Unable to build error view context for host %s: %s' % (request.get_host(), str(exc)))
+        return view_data
+
+    responses = response_list_to_dict(grequests.map(view_requests))
+
+    if whoami_url and responses.has_key(whoami_url):
+        view_data['user'] = Profile(responses[whoami_url], summary=False)
+
+    if site_url and responses.has_key(site_url):
+        view_data['site'] = Site(responses[site_url])
+
+    return view_data
+
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
     """
     generates identifies that are used as cache busters in querystrings
@@ -249,72 +282,19 @@ class LegalView(object):
 class ErrorView(object):
     @staticmethod
     def not_found(request):
-        view_data = {}
-        view_requests = []
-
-        if request.COOKIES.has_key('access_token'):
-            request.access_token = request.COOKIES['access_token']
-            whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
-            view_requests.append(grequests.get(whoami_url, params=params, headers=headers))
-
-        site_url, params, headers = Site.build_request(request.get_host())
-        view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
-
-        responses = response_list_to_dict(grequests.map(view_requests))
-        if request.whoami_url:
-            profile = Profile(responses[whoami_url], summary=False)
-            view_data['user'] = profile
-
-        site = Site(responses[site_url])
-        view_data['site'] = site
-
+        view_data = build_error_view_data(request, include_user=True)
         context = RequestContext(request, view_data)
         return HttpResponseNotFound(loader.get_template('404.html').render(context))
 
     @staticmethod
     def forbidden(request):
-        view_data = {}
-        view_requests = []
-
-        if request.COOKIES.has_key('access_token'):
-            request.access_token = request.COOKIES['access_token']
-            whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
-            view_requests.append(grequests.get(whoami_url, params=params, headers=headers))
-
-        site_url, params, headers = Site.build_request(request.get_host())
-        view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
-
-        responses = response_list_to_dict(grequests.map(view_requests))
-        if request.whoami_url:
-            profile = Profile(responses[whoami_url], summary=False)
-            view_data['user'] = profile
-
-        site = Site(responses[site_url])
-        view_data['site'] = site
-
+        view_data = build_error_view_data(request, include_user=True)
         context = RequestContext(request, view_data)
         return HttpResponseForbidden(loader.get_template('403.html').render(context))
 
     @staticmethod
     def server_error(request, exception=None):
-        view_data = {}
-        view_requests = []
-
-        # if request.COOKIES.has_key('access_token'):
-        #     request.access_token = request.COOKIES['access_token']
-        #     whoami_url, params, headers = WhoAmI.build_request(request.get_host(), request.access_token)
-        #     view_requests.append(grequests.get(whoami_url, params=params, headers=headers))
-
-        site_url, params, headers = Site.build_request(request.get_host())
-        view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
-
-        responses = response_list_to_dict(grequests.map(view_requests))
-        # if request.whoami_url:
-        #     profile = Profile(responses[whoami_url], summary=False)
-        #     view_data['user'] = profile
-
-        site = Site(responses[site_url])
-        view_data['site'] = site
+        view_data = build_error_view_data(request)
 
         # Provide detailed error if returned in the response.
         if hasattr(exception, 'detail'):
@@ -326,13 +306,7 @@ class ErrorView(object):
 
     @staticmethod
     def requires_login(request):
-        view_data = {}
-        view_requests = []
-
-        site_url, params, headers = Site.build_request(request.get_host())
-        view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
-        responses = response_list_to_dict(grequests.map(view_requests))
-        view_data['site'] = Site(responses[site_url])
+        view_data = build_error_view_data(request)
         view_data['logout'] = True
 
         context = RequestContext(request, view_data)


### PR DESCRIPTION
Getting occasional unhandled exceptions in production, when vulnerability scanners don't use a valid host header.

Failure mode:
  - The 500 is caused by an invalid/unrecognized Host header.
  - ContextMiddleware calls Site.build_request(), which attempts custom-domain resolution through Site.resolve_cname().
  - The hosts API returns 404, which raises APIException.
  - The 500 handler then performs the same host lookup again while rendering the error page, causing the failure to recur.
