### PR TITLE
fix attachment deletion auth

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -179,7 +179,13 @@ def process_attachments(request, comment):
     if request.POST.get('attachments-delete'):
         attachments_delete = request.POST.get('attachments-delete').split(",")
         for fileHash in attachments_delete:
-            Attachment.delete(request.get_host(), Comment.api_path_fragment, comment.id, fileHash)
+            Attachment.delete(
+                request.get_host(),
+                Comment.api_path_fragment,
+                comment.id,
+                fileHash,
+                access_token=request.access_token,
+            )
 
     # Check if any files have been uploaded with the request.
     if request.FILES.has_key('attachments'):


### PR DESCRIPTION
Attachment deletion requests were not passing auth token to backend