### PR TITLE
don't bother looking up IP addresses, and cache missing hostnames

### DIFF
--- a/core/api/resources.py
+++ b/core/api/resources.py
@@ -1,4 +1,5 @@
 import json
+import socket
 
 from django.conf import settings
 
@@ -18,6 +19,9 @@ import pylibmc as memcache
 
 logger = logging.getLogger('microcosm.middleware')
 mc = memcache.Client(['%s:%d' % (settings.MEMCACHE_HOST, settings.MEMCACHE_PORT)])
+
+NEGATIVE_CNAME_CACHE_VALUE = '__missing__'
+NEGATIVE_CNAME_CACHE_TTL = 86400
 
 RESOURCE_PLURAL = {
     'event': 'events',
@@ -47,6 +51,29 @@ def build_url(host, path_fragments):
     return get_subdomain_url(host) + join_path_fragments(path_fragments)
 
 
+def split_host_port(host):
+    if host.startswith('['):
+        return host[1:].split(']', 1)[0]
+    return host.split(':', 1)[0]
+
+
+def is_ip_address(host):
+    host = split_host_port(host)
+
+    for family in [socket.AF_INET, socket.AF_INET6]:
+        try:
+            socket.inet_pton(family, host)
+            return True
+        except (AttributeError, socket.error):
+            pass
+
+    try:
+        socket.inet_aton(host)
+        return host.count('.') == 3
+    except socket.error:
+        return False
+
+
 def get_subdomain_url(host):
     """
     urljoin and os.path.join don't behave exactly as we want, so
@@ -72,9 +99,24 @@ def get_subdomain_url(host):
         except memcache.Error as e:
             logger.error('Memcached error: %s' % str(e))
 
+        if resolved_name == NEGATIVE_CNAME_CACHE_VALUE:
+            raise APIException('Cached unresolved host %s' % host, 404)
+
         if resolved_name is None:
-            resolved_name = Site.resolve_cname(host)
-            mc.set(mc_key, resolved_name)
+            try:
+                resolved_name = Site.resolve_cname(host)
+            except APIException as e:
+                if e.status_code in [400, 404]:
+                    try:
+                        mc.set(mc_key, NEGATIVE_CNAME_CACHE_VALUE, time=NEGATIVE_CNAME_CACHE_TTL)
+                    except memcache.Error as cache_error:
+                        logger.error('Memcached error: %s' % str(cache_error))
+                raise
+
+            try:
+                mc.set(mc_key, resolved_name)
+            except memcache.Error as e:
+                logger.error('Memcached error: %s' % str(e))
         return settings.API_SCHEME + resolved_name
 
 
@@ -280,8 +322,9 @@ class Site(object):
         # TODO: separation of root site API and others
         url = settings.API_SCHEME + settings.API_DOMAIN_NAME
 
-        hostsplit = host.split(":", 1)
-        host = hostsplit[0]
+        host = split_host_port(host)
+        if is_ip_address(host):
+            raise APIException('Refusing to resolve IP host %s' % host, 404)
 
         path_fragments = [settings.API_PATH, settings.API_VERSION, 'hosts', host]
         url += join_path_fragments(path_fragments)

--- a/core/middleware/context.py
+++ b/core/middleware/context.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseNotFound
 from django.http import HttpResponseRedirect
 
 from core.api.exceptions import APIException
+from core.api.resources import is_ip_address
 from core.api.resources import Site
 from core.api.resources import WhoAmI
 
@@ -48,6 +49,9 @@ class ContextMiddleware():
             request.view_requests.append(grequests.get(request.site_url, params=params, headers=headers))
         except APIException as e:
             if e.status_code in [400, 404]:
-                logger.warning('Rejecting unresolved host %s: %s' % (request.get_host(), str(e)))
+                if is_ip_address(request.get_host()):
+                    logger.info('Rejecting IP host header %s' % request.get_host())
+                else:
+                    logger.warning('Rejecting unresolved host %s: %s' % (request.get_host(), str(e)))
                 return HttpResponseNotFound()
             raise

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -17,7 +17,10 @@ from core.api.resources import Microcosm
 from core.api.resources import Profile
 from core.api.resources import Site
 from core.api.resources import Event
+from core.api.resources import NEGATIVE_CNAME_CACHE_TTL
+from core.api.resources import NEGATIVE_CNAME_CACHE_VALUE
 from core.api.resources import build_url
+from core.api.resources import is_ip_address
 from core.api.exceptions import APIException
 from core.middleware.context import ContextMiddleware
 from core.views import ErrorView
@@ -77,6 +80,44 @@ class BuildURLTests(unittest.TestCase):
     def testFailCustomDomains(self):
         with self.assertRaises(APIException):
             build_url((BuildURLTests.subdomain_key + 'example.org'), ['resource', '1', 'ex/tra'])
+
+    @patch('requests.get')
+    def testRejectsIpHostsWithoutLookup(self, mock_get):
+        with self.assertRaises(APIException) as context:
+            build_url('139.162.251.45', ['resource'])
+
+        assert context.exception.status_code == 404
+        assert 'Refusing to resolve IP host 139.162.251.45' == context.exception.message
+        assert not mock_get.called
+
+    def testIsIpAddress(self):
+        assert is_ip_address('139.162.251.45')
+        assert is_ip_address('139.162.251.45:443')
+        assert not is_ip_address('islingtoncc.microcosm.app')
+
+    @patch('core.api.resources.mc')
+    @patch('core.api.resources.Site.resolve_cname')
+    def testCachedNegativeHostSkipsLookup(self, mock_resolve_cname, mock_mc):
+        mock_mc.get.return_value = NEGATIVE_CNAME_CACHE_VALUE
+
+        with self.assertRaises(APIException) as context:
+            build_url('missing.example.org', ['resource'])
+
+        assert context.exception.status_code == 404
+        assert 'Cached unresolved host missing.example.org' == context.exception.message
+        assert not mock_resolve_cname.called
+
+    @patch('core.api.resources.mc')
+    @patch('core.api.resources.Site.resolve_cname')
+    def testUnknownHostIsNegativeCached(self, mock_resolve_cname, mock_mc):
+        mock_mc.get.return_value = None
+        mock_resolve_cname.side_effect = APIException('Error resolving CNAME missing.example.org', 404)
+
+        with self.assertRaises(APIException) as context:
+            build_url('missing.example.org', ['resource'])
+
+        assert context.exception.status_code == 404
+        mock_mc.set.assert_called_once_with('missing.example.org_cname', NEGATIVE_CNAME_CACHE_VALUE, time=NEGATIVE_CNAME_CACHE_TTL)
 
 
 class PaginationTests(unittest.TestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -46,6 +46,7 @@ from core.api.resources import Profile
 from core.api.resources import response_list_to_dict
 from core.api.resources import Site
 from core.api.resources import WhoAmI
+from core.api.resources import is_ip_address
 
 from core.api.resources import build_url
 
@@ -71,7 +72,10 @@ def build_error_view_data(request, include_user=False):
         site_url, params, headers = Site.build_request(request.get_host())
         view_requests.append(grequests.get(site_url, params=params, headers=headers))
     except APIException as exc:
-        logger.warning('Unable to build error view context for host %s: %s' % (request.get_host(), str(exc)))
+        if is_ip_address(request.get_host()):
+            logger.info('Skipping error view context for IP host header %s' % request.get_host())
+        else:
+            logger.warning('Unable to build error view context for host %s: %s' % (request.get_host(), str(exc)))
         return view_data
 
     responses = response_list_to_dict(grequests.map(view_requests))


### PR DESCRIPTION
Fix some of the errors in the logs.

We're trying to look ip addresses up as microcosm sites, and we're also not adding failed lookups to the cache so we keep retrying.